### PR TITLE
feat : 일지 추가 시 관심온도 증가 로직 추가

### DIFF
--- a/src/main/java/com/ajou_nice/with_pet/domain/entity/Dog.java
+++ b/src/main/java/com/ajou_nice/with_pet/domain/entity/Dog.java
@@ -84,6 +84,10 @@ public class Dog extends BaseEntity {
         this.socializationTemperature = this.socializationTemperature + score;
     }
 
+    public void updateAffectionTemperature(double temp){
+        this.affectionTemperature = temp;
+    }
+
     public static Dog of(DogInfoRequest dogInfoRequest, Party party, DogSize dogSize) {
         //이미지 null 체크 null이면 기본이미지로 insert
         String img = dogInfoRequest.getDog_img();

--- a/src/main/java/com/ajou_nice/with_pet/repository/custom/userdiary/DiaryRepositoryCustom.java
+++ b/src/main/java/com/ajou_nice/with_pet/repository/custom/userdiary/DiaryRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface DiaryRepositoryCustom {
     List<Diary> findByMonthDate(Long userId, Long dogId, Long categoryId, LocalDate month, String petsitterCheck);
 
     List<Diary> findByDayDate(Long userId, Long dogId, Long categoryId, LocalDate parse, String petsitterCheck);
+    Long countDiaryDay(Long dogId,LocalDate createdAt);
+    Long countDiary(Long dogId, LocalDate createdAt);
 }

--- a/src/main/java/com/ajou_nice/with_pet/repository/custom/userdiary/DiaryRepositoryImpl.java
+++ b/src/main/java/com/ajou_nice/with_pet/repository/custom/userdiary/DiaryRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.ajou_nice.with_pet.domain.entity.Diary;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
@@ -30,7 +31,8 @@ public class DiaryRepositoryImpl extends QuerydslRepositorySupport implements
                 .where(diary.dog.party.eq(userParty.party).and(userParty.user.userId.eq(userId)
                                 .and(diary.createdAt.between(month.withDayOfMonth(1),
                                         month.withDayOfMonth(month.lengthOfMonth())))),
-                        containsDog(dogId), containsCategory(categoryId),containsPetsitter(petsitterCheck))
+                        containsDog(dogId), containsCategory(categoryId),
+                        containsPetsitter(petsitterCheck))
                 .orderBy(diary.createdAt.desc())
                 .fetch();
         return userDiaries;
@@ -42,10 +44,23 @@ public class DiaryRepositoryImpl extends QuerydslRepositorySupport implements
         List<Diary> userDiaries = queryFactory.select(diary).from(diary, userParty)
                 .where(diary.dog.party.eq(userParty.party).and(userParty.user.userId.eq(userId)
                                 .and(diary.createdAt.eq(day))),
-                        containsDog(dogId), containsCategory(categoryId), containsPetsitter(petsitterCheck))
+                        containsDog(dogId), containsCategory(categoryId),
+                        containsPetsitter(petsitterCheck))
                 .orderBy(diary.createdAt.desc())
                 .fetch();
         return userDiaries;
+    }
+
+    @Override
+    public Long countDiaryDay(Long dogId, LocalDate createdAt) {
+        return queryFactory.select(diary.dog.dogId.countDistinct()).from(diary)
+                .where(diary.createdAt.between(createdAt, LocalDate.now()).and(diary.dog.dogId.eq(dogId))).fetchOne();
+    }
+
+    @Override
+    public Long countDiary(Long dogId, LocalDate createdAt) {
+        return queryFactory.select(diary.dog.dogId.count()).from(diary)
+                .where(diary.createdAt.between(createdAt, LocalDate.now()).and(diary.dog.dogId.eq(dogId))).fetchOne();
     }
 
     private BooleanExpression containsDog(Long dogId) {


### PR DESCRIPTION
- chatGPT가 제공한 로직 추가
- 기본온도 + (일지 개수 + 1) - ((반려견 등록된 시점부터 지금까지의 날짜 차이 - 다이어리 등록일 수) * 0.5)